### PR TITLE
Fix example logging file path function call

### DIFF
--- a/doc/other/troubleshooting.md
+++ b/doc/other/troubleshooting.md
@@ -36,7 +36,7 @@ Run `:checkhealth mcphub` in Neovim to check for common issues
 {
     level = vim.log.levels.DEBUG,
     to_file = true,
-    file_path = vim.fn.expande("~/mcphub.log"),
+    file_path = vim.fn.expand("~/mcphub.log"),
 }
 ```
 - Test tools and resources individually to isolate issues


### PR DESCRIPTION
## Description

This is a trivial docs fix that will save users a few seconds of their time :)

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
